### PR TITLE
Add batch unsubscribing functionality for gitea

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Codacy Badge](https://api.codacy.com/project/badge/Grade/352635b2c8534b0086b5a153db7c82e9)](https://app.codacy.com/gh/BoYanZh/Joint-Teapot?utm_source=github.com&utm_medium=referral&utm_content=BoYanZh/Joint-Teapot&utm_campaign=Badge_Grade_Settings)
 
-A handy tool for TAs in JI to handle works through [Gitea](https://focs.ji.sjtu.edu.cn/git/), [Canvas](https://umjicanvas.com/), and [JOJ](https://joj.sjtu.edu.cn/). Joint is related to JI and also this tool which join websites together. Teapot means to hold Gitea, inspired by [@nichujie](https://github.com/nichujie).
+A handy tool for TAs in JI to handle works through [Gitea](https://focs.ji.sjtu.edu.cn/git/), [Canvas](https://umjicanvas.com/), [JOJ](https://joj.sjtu.edu.cn/) and [Mattermost](https://focs.ji.sjtu.edu.cn/mm/). Joint is related to JI and also this tool which join websites together. Teapot means to hold Gitea, inspired by [@nichujie](https://github.com/nichujie).
 
 This tool is still under heavy development. The docs may not be updated on time, and all the features are provided with the probability to change.
 
@@ -12,10 +12,7 @@ This tool is still under heavy development. The docs may not be updated on time,
 
 ```bash
 python3 -m venv env # you only need to do that once
-# each time when you need this venv, if on Linux / macOS use
-source env/bin/activate
-# or this if on Windows
-source env/Scripts/activate
+source env/Scripts/activate # each time when you need this venv
 ```
 
 ### Install
@@ -36,57 +33,20 @@ pytest -svv
 
 ## Commands & Features
 
-### `archive-all-repos`
-archive all repos in gitea organization
-
-### `check-issues`
-check the existence of issue by title on gitea
-
-### `checkout-releases`
-checkout git repo to git tag fetched from gitea by release name, with due date
-
-### `clone-all-repos`
-clone all gitea repos to local
-
-### `close-all-issues`
-close all issues and pull requests in gitea organization
-
-### `create-channels-on-mm`
-create channels for student groups according to group information on gitea. Optionally specify a prefix to ignore all repos whose names do not start with it.
-
-Example: `python3 -m joint_teapot create_channels_for_groups p1` will fetch all repos whose names start with `"p1"` and create same-name channels on mm for these repos. Members of a repo will be added to the corresponding channel.
-
-### `create-issues`
-create issues on gitea
-
-### `create-personal-repos`
-create personal repos on gitea for all canvas students
-
-### `create-teams`
-create teams on gitea by canvas groups
-
-### `create-webhooks-for-mm`
-Create a pair of webhooks on gitea and mm for all student groups on gitea, and configure them so that updates on gitea will be pushed to the mm channel. Optionally specify a prefix to ignore all repos whose names do not start with it.
-
-Example: `python3 -m joint_teapot create-webhooks-for-mm p1` will fetch all repos whose names start with `"p1"` and create two-way webhooks for these repos. All repos should already have same-name mm channels. If not, use `create-channels-on-mm` to create them.
-
-### `get-no-collaborator-repos`
-list all repos with no collaborators
-
-### `get-public-keys`
-list all public keys on gitea
-
-### `get-repos-status`
-list status of all repos with conditions
-
-### `invite-to-teams`
-invite all canvas students to gitea teams by team name
-
-### `prepare-assignment-dir`
-prepare assignment dir from extracted canvas "Download Submissions" zip
-
-### `upload-assignment-grades`
-upload assignment grades to canvas from grade file (GRADE.txt by default), read the first line as grade, the rest as comments
+- `archive-all-repos`:          archive all repos in gitea organization
+- `check-issues`:               check the existence of issue by title on gitea
+- `checkout-releases`:          checkout git repo to git tag fetched from gitea by release name, with due date
+- `clone-all-repos`:            clone all gitea repos to local
+- `close-all-issues`:           close all issues and pull requests in gitea organization
+- `create-issues`:              create issues on gitea
+- `create-personal-repos`:      create personal repos on gitea for all canvas students
+- `create-teams`:               create teams on gitea by canvas groups
+- `get-no-collaborator-repos`:  list all repos with no collaborators
+- `get-public-keys`:            list all public keys on gitea
+- `get-repos-status`:           list status of all repos with conditions
+- `invite-to-teams`:            invite all canvas students to gitea teams by team name
+- `prepare-assignment-dir`:     prepare assignment dir from extracted canvas "Download Submissions" zip
+- `upload-assignment-grades`:   upload assignment grades to canvas from grade file (GRADE.txt by default), read the first line as grade, the rest as comments
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,10 @@ This tool is still under heavy development. The docs may not be updated on time,
 
 ```bash
 python3 -m venv env # you only need to do that once
-source env/Scripts/activate # each time when you need this venv
+# each time when you need this venv, if on Linux / macOS use
+source env/bin/activate
+# or this if on Windows
+source env/Scripts/activate
 ```
 
 ### Install
@@ -33,20 +36,62 @@ pytest -svv
 
 ## Commands & Features
 
-- `archive-all-repos`:          archive all repos in gitea organization
-- `check-issues`:               check the existence of issue by title on gitea
-- `checkout-releases`:          checkout git repo to git tag fetched from gitea by release name, with due date
-- `clone-all-repos`:            clone all gitea repos to local
-- `close-all-issues`:           close all issues and pull requests in gitea organization
-- `create-issues`:              create issues on gitea
-- `create-personal-repos`:      create personal repos on gitea for all canvas students
-- `create-teams`:               create teams on gitea by canvas groups
-- `get-no-collaborator-repos`:  list all repos with no collaborators
-- `get-public-keys`:            list all public keys on gitea
-- `get-repos-status`:           list status of all repos with conditions
-- `invite-to-teams`:            invite all canvas students to gitea teams by team name
-- `prepare-assignment-dir`:     prepare assignment dir from extracted canvas "Download Submissions" zip
-- `upload-assignment-grades`:   upload assignment grades to canvas from grade file (GRADE.txt by default), read the first line as grade, the rest as comments
+### `archive-all-repos`
+archive all repos in gitea organization
+
+### `check-issues`
+check the existence of issue by title on gitea
+
+### `checkout-releases`
+checkout git repo to git tag fetched from gitea by release name, with due date
+
+### `clone-all-repos`
+clone all gitea repos to local
+
+### `close-all-issues`
+close all issues and pull requests in gitea organization
+
+### `create-channels-on-mm`
+create channels for student groups according to group information on gitea. Optionally specify a prefix to ignore all repos whose names do not start with it.
+
+Example: `python3 -m joint_teapot create_channels_for_groups p1` will fetch all repos whose names start with `"p1"` and create same-name channels on mm for these repos. Members of a repo will be added to the corresponding channel.
+
+### `create-issues`
+create issues on gitea
+
+### `create-personal-repos`
+create personal repos on gitea for all canvas students
+
+### `create-teams`
+create teams on gitea by canvas groups
+
+### `create-webhooks-for-mm`
+Create a pair of webhooks on gitea and mm for all student groups on gitea, and configure them so that updates on gitea will be pushed to the mm channel. Optionally specify a prefix to ignore all repos whose names do not start with it.
+
+Example: `python3 -m joint_teapot create-webhooks-for-mm p1` will fetch all repos whose names start with `"p1"` and create two-way webhooks for these repos. All repos should already have same-name mm channels. If not, use `create-channels-on-mm` to create them.
+
+### `get-no-collaborator-repos`
+list all repos with no collaborators
+
+### `get-public-keys`
+list all public keys on gitea
+
+### `get-repos-status`
+list status of all repos with conditions
+
+### `invite-to-teams`
+invite all canvas students to gitea teams by team name
+
+### `prepare-assignment-dir`
+prepare assignment dir from extracted canvas "Download Submissions" zip
+
+### `unsubscribe-from-repos`
+Unsubscribe from all repos in the organization specified in the config file where the repo name matches a given regex expression.
+
+Example: `python3 -m joint_teapot unsubscribe-from-repos '\d{12}$'` will remove all repos whose names end with a student ID number from your gitea subscription list. Refer to the Python `re` module docs for more info about regex.
+
+### `upload-assignment-grades`
+upload assignment grades to canvas from grade file (GRADE.txt by default), read the first line as grade, the rest as comments
 
 ## License
 

--- a/joint_teapot/app.py
+++ b/joint_teapot/app.py
@@ -165,6 +165,14 @@ def create_webhooks_for_mm(prefix: str = Argument("")) -> None:
     tea.pot.mattermost.create_webhooks_for_repos(repo_names, tea.pot.gitea)
 
 
+@app.command(
+    "unsubscribe-from-repos",
+    help="unsubscribe from all repos whose name match the given regex pattern",
+)
+def unsubscribe_from_repos(pattern: str = Argument("")) -> None:
+    tea.pot.gitea.unsubscribe_from_repos(pattern)
+
+
 if __name__ == "__main__":
     try:
         app()

--- a/joint_teapot/workers/gitea.py
+++ b/joint_teapot/workers/gitea.py
@@ -399,24 +399,23 @@ class Gitea:
         return res
 
     def unsubscribe_from_repos(self, pattern: str) -> None:
-        regex = re.compile(pattern)
         subscriptions = [
             sub
             for sub in self.user_api.user_current_list_subscriptions()
             if sub.owner.login == self.org_name
-            and re.search(regex, sub.name) is not None
+            and re.search(pattern, sub.name) is not None
         ]
         if len(subscriptions) == 0:
             logger.warning(f"No subscribed repo matches the pattern {pattern}")
-        else:
-            logger.info(
-                f"{len(subscriptions)} subscriptions match the pattern {pattern}: {subscriptions[0].name} ... {subscriptions[-1].name}"
+            return
+        logger.info(
+            f"{len(subscriptions)} subscriptions match the pattern {pattern}: {[s.name for s in subscriptions]}"
+        )
+        for sub in subscriptions:
+            self.repository_api.user_current_delete_subscription(
+                self.org_name, sub.name
             )
-            for sub in subscriptions:
-                self.repository_api.user_current_delete_subscription(
-                    self.org_name, sub.name
-                )
-                logger.info(f"Unsubscribed from {sub.name}")
+            logger.info(f"Unsubscribed from {sub.name}")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This PR adds a `unsubscribe-from-repos` command that helps TAs easily unsubscribe from student repos to avoid being email flooded by gitea.

Note: line break issue is not fixed. It is worked around for now, and needs a force push to be removed from the commit history. This PR might also break things since there were a lot of merge conflicts. Please review carefully.