### PR TITLE
feat: Option to invite teaching team when creating MM channels

### DIFF
--- a/joint_teapot/app.py
+++ b/joint_teapot/app.py
@@ -140,18 +140,23 @@ def upload_assignment_grades(assignments_dir: Path, assignment_name: str) -> Non
     help="create channels for student groups according to group information on"
     " gitea",
 )
-def create_channels_on_mm(prefix: str = Option(""), suffix: str = Option("")) -> None:
+def create_channels_on_mm(
+    prefix: str = Option(""),
+    suffix: str = Option(""),
+    invite_teaching_team: bool = Option(False)
+) -> None:
     groups = {
         group_name: members
         for group_name, members in tea.pot.gitea.get_all_teams().items()
         if group_name.startswith(prefix)
     }
     logger.info(
-        f"{len(groups)} channel(s) to be created "
-        + (f"with suffix {suffix}" if suffix else "")
+        f"{len(groups)} channel(s) to be created"
+        + (f" with suffix {suffix}" if suffix else "")
+        + (f", inviting teaching team" if invite_teaching_team else "")
         + f": {','.join(groups.keys())}"
     )
-    tea.pot.mattermost.create_channels_for_groups(groups, suffix)
+    tea.pot.mattermost.create_channels_for_groups(groups, suffix, invite_teaching_team)
 
 
 @app.command(

--- a/joint_teapot/config.py
+++ b/joint_teapot/config.py
@@ -29,6 +29,9 @@ class Settings(BaseSettings):
     mattermost_suffix: str = "/mm"
     mattermost_access_token: str = ""
     mattermost_team: str = ""
+    mattermost_teaching_team = [
+        "manuel",
+    ]
 
     # sid
     joj_sid: str = ""

--- a/joint_teapot/workers/mattermost.py
+++ b/joint_teapot/workers/mattermost.py
@@ -40,7 +40,7 @@ class Mattermost:
             return
 
     def create_channels_for_groups(
-        self, groups: Dict[str, List[str]], suffix: str = ""
+        self, groups: Dict[str, List[str]], suffix: str = "", invite_teaching_team: bool = False
     ) -> None:
         for group_name, members in groups.items():
             channel_name = group_name + suffix
@@ -59,6 +59,8 @@ class Mattermost:
                     f"Error when creating channel {channel_name}: {e} Perhaps channel already exists?"
                 )
                 continue
+            if invite_teaching_team:
+                members.extend(settings.mattermost_teaching_team)
             for member in members:
                 try:
                     mmuser = self.endpoint.users.get_user_by_username(member)


### PR DESCRIPTION
This automatically invites everyone in the configured teaching team to each of the channels created. Manuel asked me to do this today and I thought it would be helpful upstream.

Efficiency could be boosted if the user-id-by-username lookup was done only once per TT member, but I don't think the optimization is really necessary.

Thanks for reviewing.