### PR TITLE
feat: extend create-issues with --regex and --file

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,12 @@ Example: `python3 -m joint_teapot create_channels_for_groups --prefix p1 -suffix
 
 ### `create-issues`
 
-create issues on gitea
+create issues on gitea. Specify a list of repos (use `--regex` to match against list of patterns), a title, and a body (use `--file` to read from file), in this order.
+
+Examples (run both with `python3 -m joint_teapot create-issues`):
+
+- `pgroup-08 pgroup-17 "Hurry up" "You are running out of time"` will create an issue in these two pgroups.
+- `--regex "^pgroup" "Final submission" --file "./issues/final-submission.md"` will create an issue in all pgroups, with body content read from said file.
 
 ### `create-personal-repos`
 

--- a/joint_teapot/app.py
+++ b/joint_teapot/app.py
@@ -63,8 +63,9 @@ def create_issue_for_repos(
     title: str,
     body: str = Argument(..., help="issue body, or, if --from-file is set, filepath to issue body"),
     from_file: bool = Option(False, "--file/--body"),
+    use_regex: bool = Option(False, "--regex", help="repo_names takes list of regexes if set"),
 ) -> None:
-    tea.pot.create_issue_for_repos(repo_names, title, body, from_file)
+    tea.pot.create_issue_for_repos(repo_names, title, body, from_file, use_regex)
 
 
 @app.command("create-milestones", help="create milestones on gitea")

--- a/joint_teapot/app.py
+++ b/joint_teapot/app.py
@@ -58,8 +58,13 @@ def clone_all_repos() -> None:
 
 
 @app.command("create-issues", help="create issues on gitea")
-def create_issue_for_repos(repo_names: List[str], title: str, body: str) -> None:
-    tea.pot.create_issue_for_repos(repo_names, title, body)
+def create_issue_for_repos(
+    repo_names: List[str],
+    title: str,
+    body: str = Argument(..., help="issue body, or, if --from-file is set, filepath to issue body"),
+    from_file: bool = Option(False, "--file/--body"),
+) -> None:
+    tea.pot.create_issue_for_repos(repo_names, title, body, from_file)
 
 
 @app.command("create-milestones", help="create milestones on gitea")

--- a/joint_teapot/teapot.py
+++ b/joint_teapot/teapot.py
@@ -113,10 +113,26 @@ class Teapot:
             self.git.repo_clean_and_checkout(repo_name, "master")
 
     def create_issue_for_repos(
-        self, repo_names: List[str], title: str, body: str
+        self, repo_names: List[str], title: str, body: str, from_file: bool = False
     ) -> None:
+        if from_file:
+            try:
+                f = open(body)
+                content = f.read()
+                f.close()
+            except FileNotFoundError:
+                logger.error(f"file {body} not found")
+                return
+            except Exception as e:
+                logger.exception("Error occurred when opening file {body}:")
+                logger.error(e)
+                return
+        else:
+            content = body
+
         for repo_name in repo_names:
-            self.gitea.create_issue(repo_name, title, body)
+            self.gitea.create_issue(repo_name, title, content)
+
 
     def create_milestone_for_repos(
         self, repo_names: List[str], title: str, description: str, due_on: datetime

--- a/joint_teapot/teapot.py
+++ b/joint_teapot/teapot.py
@@ -1,4 +1,5 @@
 import functools
+import re
 from datetime import datetime
 from typing import Any, Callable, Dict, List, Optional, TypeVar
 
@@ -113,7 +114,12 @@ class Teapot:
             self.git.repo_clean_and_checkout(repo_name, "master")
 
     def create_issue_for_repos(
-        self, repo_names: List[str], title: str, body: str, from_file: bool = False
+        self,
+        repo_names: List[str],
+        title: str,
+        body: str,
+        from_file: bool = False,
+        use_regex: bool = False,
     ) -> None:
         if from_file:
             try:
@@ -130,7 +136,19 @@ class Teapot:
         else:
             content = body
 
-        for repo_name in repo_names:
+        affected_repos = []
+        if use_regex:
+            all_repos = self.gitea.get_all_repo_names()
+            for pattern in repo_names:
+                affected_repos.extend([
+                    repo
+                    for repo in all_repos
+                    if re.search(pattern, repo) is not None
+                ])
+        else:
+            affected_repos = repo_names
+
+        for repo_name in affected_repos:
             self.gitea.create_issue(repo_name, title, content)
 
 

--- a/joint_teapot/workers/gitea.py
+++ b/joint_teapot/workers/gitea.py
@@ -328,7 +328,7 @@ class Gitea:
         assignees = []
         if assign_every_collaborators:
             assignees = [
-                item.username
+                item.login
                 for item in list_all(
                     self.repository_api.repo_list_collaborators,
                     self.org_name,
@@ -340,6 +340,7 @@ class Gitea:
             repo_name,
             body={"title": title, "body": body, "assignees": assignees},
         )
+        logger.info(f"Created issue \"{title}\" in {repo_name}")
 
     def create_milestone(
         self,


### PR DESCRIPTION
This PR might be a bit controversial. In order not to break backward compatibility I abused boolean typer options to mimic one that takes an argument. For example,

```
joint_teapot create-issues --regex pgroup "title" --file issue.md
```

creates an illusion that `pgroup` is an argument to `--regex` and `issue.md` is to `--file`, but they are not. This command does the exact same thing:

```
joint_teapot create-issues pgroup "title" issue.md --file --regex
```

Obviously this is a hack, but (1) it gets the job done and (2) doesn't break userland. What do you think?

Thanks for reviewing.