### PR TITLE
fix: use `integration_id` to get students' jAccount username

### DIFF
--- a/joint_teapot/workers/gitea.py
+++ b/joint_teapot/workers/gitea.py
@@ -68,10 +68,9 @@ class Gitea:
 
     @lru_cache()
     def _get_username_by_canvas_student(self, student: User) -> str:
-        res = self.user_api.user_search(q=student.login_id, limit=1)
-        if len(res["data"]) == 0:
+        if student.email == None or student.email.find("@") == -1:
             raise Exception(f"{student} not found in Gitea")
-        return res["data"][0]["username"]
+        return student.email.split("@")[0]
 
     def add_canvas_students_to_teams(
         self, students: PaginatedList, team_names: List[str]

--- a/joint_teapot/workers/gitea.py
+++ b/joint_teapot/workers/gitea.py
@@ -68,7 +68,7 @@ class Gitea:
 
     @lru_cache()
     def _get_username_by_canvas_student(self, student: User) -> str:
-        if student.integration_id == None:
+        if student.integration_id is None:
             raise Exception(f"{student} id not found in Gitea")
         return student.integration_id
 

--- a/joint_teapot/workers/gitea.py
+++ b/joint_teapot/workers/gitea.py
@@ -68,9 +68,9 @@ class Gitea:
 
     @lru_cache()
     def _get_username_by_canvas_student(self, student: User) -> str:
-        if student.email == None or student.email.find("@") == -1:
-            raise Exception(f"{student} not found in Gitea")
-        return student.email.split("@")[0]
+        if student.integration_id == None:
+            raise Exception(f"{student} id not found in Gitea")
+        return student.integration_id
 
     def add_canvas_students_to_teams(
         self, students: PaginatedList, team_names: List[str]


### PR DESCRIPTION
The `integration_id` field in canvas user is better because email can be set by user but integration_id is set by the orgnization.