### PR TITLE
fix: gitea get team id by name

### DIFF
--- a/joint_teapot/workers/gitea.py
+++ b/joint_teapot/workers/gitea.py
@@ -64,7 +64,7 @@ class Gitea:
 
     @lru_cache()
     def _get_team_id_by_name(self, name: str) -> int:
-        res = self.organization_api.team_search(self.org_name, q=str(name), limit=1)
+        res = self.organization_api.team_search(self.org_name, q=str(name), limit=1).to_dict()
         if len(res["data"] or []) == 0:
             raise Exception(
                 f"{name} not found by name in Gitea. Possible reason: you did not join this team."


### PR DESCRIPTION
In `_get_team_id_by_name`, it will throw 
>TypeError: 'InlineResponse200' object is not subscriptable 

Can be solve by manually change it into a `dict` type .