### PR TITLE
fix: handle invalid space `\xa0` in repo_name_converter

### DIFF
--- a/joint_teapot/utils/main.py
+++ b/joint_teapot/utils/main.py
@@ -33,5 +33,5 @@ def default_repo_name_convertor(user: User) -> str:
     login_id, name = user.login_id, user.name
     eng = re.sub("[\u4e00-\u9fa5]", "", name)
     eng = eng.replace(",", "")
-    eng = eng.title().replace(" ", "")
+    eng = eng.title().replace(" ", "").replace(u'\xa0', '')
     return f"{eng}{login_id}"


### PR DESCRIPTION
Some usernames created by JI IT contain invalid character, including Unicode Non-Breaking Spaces. Handle this.