### PR TITLE
fix: canvas site change & wrong repository name generations

### DIFF
--- a/joint_teapot/config.py
+++ b/joint_teapot/config.py
@@ -10,7 +10,7 @@ class Settings(BaseSettings):
     """
 
     # canvas
-    canvas_domain_name: str = "jicanvas.com"
+    canvas_domain_name: str = "oc.sjtu.edu.cn"
     canvas_suffix: str = "/"
     canvas_access_token: str = ""
     canvas_course_id: int = 0

--- a/joint_teapot/utils/main.py
+++ b/joint_teapot/utils/main.py
@@ -30,8 +30,8 @@ def percentile(
 
 
 def default_repo_name_convertor(user: User) -> str:
-    login_id, name = user.login_id, user.name
+    sis_user_id, name = user.sis_user_id, user.name
     eng = re.sub("[\u4e00-\u9fa5]", "", name)
     eng = eng.replace(",", "")
     eng = eng.title().replace(" ", "").replace("\xa0", "")
-    return f"{eng}{login_id}"
+    return f"{eng}{sis_user_id}"


### PR DESCRIPTION
- jicanvas.com is deprecated now. 
- Due to changes in `login_id` logic, individual repositories now have jaccount in the name (instead of SID) so we have to use `sis_user_id` now.