### PR TITLE
feat: update team naming format

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ Example: `python3 -m joint_teapot create-personal-repos --suffix "-p1"` will cre
 
 ### `create-teams`
 
-create teams on gitea by canvas groups
+create teams on gitea by canvas groups. To integrate with webhooks, it's recommended to set suffix to `-gitea`.
 
 ### `create-webhooks-for-mm`
 

--- a/joint_teapot/app.py
+++ b/joint_teapot/app.py
@@ -184,7 +184,7 @@ def upload_assignment_grades(assignments_dir: Path, assignment_name: str) -> Non
 @app.command(
     "create-group-channels-on-mm",
     help="create channels for student groups according to group information on"
-    " gitea",
+    " gitea; to integrate with webhooks, it's recommended to set suffix to '-gitea'",
 )
 def create_group_channels_on_mm(
     prefix: str = Option(""),
@@ -221,7 +221,7 @@ def create_personal_channels_on_mm(
     "and configure them so that updates on gitea will be pushed to the mm channel",
 )
 def create_webhooks_for_mm(
-    regex: str = Argument(""), git_suffix: bool = Option(False)
+    regex: str = Argument(""), gitea_suffix: bool = Option(True)
 ) -> None:
     repo_names = [
         group_name
@@ -229,7 +229,9 @@ def create_webhooks_for_mm(
         if re.match(regex, group_name)
     ]
     logger.info(f"{len(repo_names)} pair(s) of webhooks to be created: {repo_names}")
-    tea.pot.mattermost.create_webhooks_for_repos(repo_names, tea.pot.gitea, git_suffix)
+    tea.pot.mattermost.create_webhooks_for_repos(
+        repo_names, tea.pot.gitea, gitea_suffix
+    )
 
 
 @app.command(

--- a/joint_teapot/teapot.py
+++ b/joint_teapot/teapot.py
@@ -111,7 +111,7 @@ class Teapot:
                 return None
             team_name, number_str = name.split(" ")
             number = int(number_str)
-            return f"{team_name}-{number:02}"
+            return f"{team_name}{number:02}"
 
         return self.gitea.create_teams_and_repos_by_canvas_groups(
             self.canvas.students, self.canvas.groups, convertor, convertor

--- a/joint_teapot/workers/mattermost.py
+++ b/joint_teapot/workers/mattermost.py
@@ -167,12 +167,14 @@ class Mattermost:
                 logger.info(f"Added member {member} to channel {channel_name}")
 
     def create_webhooks_for_repos(
-        self, repos: List[str], gitea: Gitea, git_suffix: bool
+        self, repos: List[str], gitea: Gitea, gitea_suffix: bool
     ) -> None:
         # one group corresponds to one repo so these concepts can be used interchangeably
         for repo in repos:
-            logger.info(f"Creating webhooks for repo {gitea.org_name}/{repo}")
-            channel_name = f"{repo}-git" if git_suffix else repo
+            channel_name = f"{repo}-gitea" if gitea_suffix else repo
+            logger.info(
+                f"Creating webhooks for repo {gitea.org_name}/{repo} and channel {channel_name}"
+            )
             try:
                 mm_channel = self.endpoint.channels.get_channel_by_name(
                     self.team["id"], channel_name


### PR DESCRIPTION
Remove the hyphen between prefix and index. Now `pteam-01` becomes `pteam01`, and `pteam-01-git` becomes `pteam01-gitea`.

Help pages are modified accordingly.